### PR TITLE
#12 docomo光ルータ01版を追加

### DIFF
--- a/src/cypress/integration/docomo-hikari-router01-wifi-off.ts
+++ b/src/cypress/integration/docomo-hikari-router01-wifi-off.ts
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+it('Wi-Fi On', () => {
+  cy.visit('http://192.168.1.2/wlbasic5.htm', {
+    auth: {
+      username: Cypress.env('USER_NAME'),
+      password: Cypress.env('PASSWORD'),
+    },
+  })
+  cy.get('#wl_disable1').should('have.value', 'ON')
+
+  cy.get('#wl_disable1').select('使用しない')
+
+  cy.get('form[name="wlanSetup"]').submit()
+  cy.on('window:confirm', () => true)
+
+  cy.get('#restartNow').click()
+})

--- a/src/cypress/integration/docomo-hikari-router01-wifi-on.ts
+++ b/src/cypress/integration/docomo-hikari-router01-wifi-on.ts
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+it('Wi-Fi On', () => {
+  cy.visit('http://192.168.1.2/wlbasic5.htm', {
+    auth: {
+      username: Cypress.env('USER_NAME'),
+      password: Cypress.env('PASSWORD'),
+    },
+  })
+  cy.get('#wl_disable1').should('have.value', 'OFF')
+
+  cy.get('#wl_disable1').select('使用する')
+
+  cy.get('form[name="wlanSetup"]').submit()
+  cy.on('window:confirm', () => true)
+
+  cy.get('#restartNow').click()
+})


### PR DESCRIPTION
## 解決するチケット

fixed #12

## 修正内容

docomo 光ルータ01版のWi-Fi On/Offを追加

## その他

とりあえず5GHz帯のセカンダリSIDを有効･無効にするだけです
