### PR TITLE
chore: #106 CodeSpace用に `.env` を読み込まないよう修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
     },
   },
   "runArgs": [
-      "--env-file", "${localWorkspaceFolder}/.devcontainer/.env"
   ],
   // Set *default* container specific settings.json values on container create.
   "settings": {


### PR DESCRIPTION
## 解決するチケット

fixed #106

## 修正内容

- CodeSpace用に `.env` を読み込まないよう修正

## その他

特になし