### PR TITLE
chore: #140 typescriptのバージョンを固定化

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -54,7 +54,11 @@ const project = new awscdk.AwsCdkTypeScriptApp({
     '@types/uuid',
     'uuid',
   ],
-  devDeps: ['esbuild', 'aws-sdk-client-mock'],
+  devDeps: [
+    'esbuild',
+    'aws-sdk-client-mock',
+    'typescript@4.6.4',
+  ],
   devContainer: true,
   // description: undefined,      /* The description is just a string that helps people understand the purpose of the package. */
   // packageName: undefined,      /* The "name" in package.json. */


### PR DESCRIPTION
## 解決するチケット

fixed #140

## 修正内容

`typescript` のバージョンを `4.6.4` で固定化

## その他

特になし